### PR TITLE
Reformat Elm build errors for compatibility with Sublime Text error navigation

### DIFF
--- a/Build Systems/Elm Make.sublime-build
+++ b/Build Systems/Elm Make.sublime-build
@@ -10,9 +10,9 @@
         "--yes"
     ],
     "working_dir": "$project_path",
-    "file_regex": "(?i)^={4} \\w+ in (.+?):(\\d+):(\\d+): ={4}\\n((?:.|\\n)*?)\\n?-{4}$",
-    "error_format": "==== $type in $file:$line:$column: ====\n$message\n----",
-    "info_format": "=== $info ===",
+    "file_regex": "^\\-\\- \\w+: (?=.+ \\- (.+?):(\\d+):(\\d+))(.+) \\- .*$",
+    "error_format": "-- $type: $tag - $file:$line:$column\n$message\n",
+    "info_format": ":: $info\n",
     "syntax": "Packages/Elm Language Support/Syntaxes/Elm Compile Messages.hidden-tmLanguage",
     "color_scheme": "Packages/Color Scheme - Default/Sunburst.tmTheme",
     "null_device": "/dev/null",

--- a/Syntaxes/Elm Compile Messages.YAML-tmLanguage
+++ b/Syntaxes/Elm Compile Messages.YAML-tmLanguage
@@ -6,10 +6,10 @@ fileTypes: []
 uuid: 0e1a8891-7cc0-4991-8018-252d6f591f8f
 
 patterns:
-- comment: === Unparsed Compile Message ===
+- comment: "|> Unparsed Compile Message"
   name: comment.line.heading.3.elm-build-output
-  begin: '^(={3}) '
-  end: ' \1$'
+  begin: '^(::) '
+  end: '^\n$'
   patterns:
   - comment: elm-lang/core OR build\index.html
     name: markup.underline.link.elm-build-output
@@ -17,29 +17,32 @@ patterns:
   - comment: Successfully generated
     name: constant.language.boolean.true.elm-build-output
     match: (?i)\bsuccess\w+
-- comment: ==== MediaWiki-Formatted ====\nCompile Message\n----
+- comment: -- TAG - file:line:column\nOverview\nDetail\n
   name: meta.report.elm-build-output
   contentName: string.unquoted.elm-build-output
   begin: |-
-    (?xi)          # Minimally modified `file_regex` from `Elm Make.sublime-build`
-      ^={4}[ ]     # Leading delimiter
+    (?x)           # Minimally modified `file_regex` from `Elm Make.sublime-build`
+      ^\-\-[ ]     # Leading delimiter
       ((error)     # \2: error
       |(warning)   # \3: warning
       |\w+         # \1: any $type
-      )[ ]in[ ]    # separator
-      (.+?):       # \4: $file
-      (\d+):       # \5: $line
-      (\d+):       # \6: $column
-      [ ]={4}\n    # Trailing delimiter
+      )[:][ ]      # separator
+      (.+)         # \4: tag
+      [ ][-][ ]    # separator
+      (.+?):       # \5: $file
+      (\d+):       # \6: $line
+      (\d+)        # \7: $column
+      \n$          # End
   beginCaptures:
     '0': {name: markup.heading.4.elm-build-output}
     '1': {name: support.constant.type.elm-build-output}
     '2': {name: invalid.illegal.error.elm-build-output}
     '3': {name: invalid.deprecated.warning.elm-build-output}
-    '4': {name: markup.underline.link.elm-build-output}
-    '5': {name: constant.numeric.elm-build-output}
+    '4': {name: support.constant.type.elm-build-output}
+    '5': {name: markup.underline.link.elm-build-output}
     '6': {name: constant.numeric.elm-build-output}
-  end: ^-{4}$
+    '7': {name: constant.numeric.elm-build-output}
+  end: ^\n$
   endCaptures:
     '0': {name: meta.separator.elm-build-output}
   patterns:

--- a/Syntaxes/Elm Compile Messages.hidden-tmLanguage
+++ b/Syntaxes/Elm Compile Messages.hidden-tmLanguage
@@ -10,11 +10,11 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>^(={3}) </string>
+			<string>^(::) </string>
 			<key>comment</key>
-			<string>=== Unparsed Compile Message ===</string>
+			<string>|&gt; Unparsed Compile Message</string>
 			<key>end</key>
-			<string> \1$</string>
+			<string>^\n$</string>
 			<key>name</key>
 			<string>comment.line.heading.3.elm-build-output</string>
 			<key>patterns</key>
@@ -39,16 +39,18 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?xi)          # Minimally modified `file_regex` from `Elm Make.sublime-build`
-  ^={4}[ ]     # Leading delimiter
+			<string>(?x)           # Minimally modified `file_regex` from `Elm Make.sublime-build`
+  ^\-\-[ ]     # Leading delimiter
   ((error)     # \2: error
   |(warning)   # \3: warning
   |\w+         # \1: any $type
-  )[ ]in[ ]    # separator
-  (.+?):       # \4: $file
-  (\d+):       # \5: $line
-  (\d+):       # \6: $column
-  [ ]={4}\n    # Trailing delimiter</string>
+  )[:][ ]      # separator
+  (.+)         # \4: tag
+  [ ][-][ ]    # separator
+  (.+?):       # \5: $file
+  (\d+):       # \6: $line
+  (\d+)        # \7: $column
+  \n$          # End</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -74,25 +76,30 @@
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>markup.underline.link.elm-build-output</string>
+					<string>support.constant.type.elm-build-output</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.elm-build-output</string>
+					<string>markup.underline.link.elm-build-output</string>
 				</dict>
 				<key>6</key>
 				<dict>
 					<key>name</key>
 					<string>constant.numeric.elm-build-output</string>
 				</dict>
+				<key>7</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.elm-build-output</string>
+				</dict>
 			</dict>
 			<key>comment</key>
-			<string>==== MediaWiki-Formatted ====\nCompile Message\n----</string>
+			<string>-- TAG - file:line:column\nOverview\nDetail\n</string>
 			<key>contentName</key>
 			<string>string.unquoted.elm-build-output</string>
 			<key>end</key>
-			<string>^-{4}$</string>
+			<string>^\n$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>

--- a/elm_make.py
+++ b/elm_make.py
@@ -66,7 +66,7 @@ class ElmMakeCommand(default_exec.ExecCommand):
             info_str = result_str.strip()
             return [self.info_format.substitute(info=info_str)] if info_str else []
 
-    def format_error(shelf, type, file, region, overview, details, **kwargs):
+    def format_error(shelf, type, file, region, tag, overview, details, **kwargs):
         if type == 'warning' and not shelf.warnings:
             return None
         line = region['start']['line']


### PR DESCRIPTION
Recent updates to Sublime Text 3 have introduced the display of error “phantoms”
(dismissible one-line error summaries displayed inline at the source of the
error). These, as well as the editor’s next/previous error navigation with
(Shift-)F4 were incompatible with the multi-line error pattern matching that
was previously used.

This new error formatting includes all required information for the display of
error “phantoms” on a single line, which brings the above broken features back
to life.

Fixes #4