### PR TITLE
README: Add troubleshooting tip for menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@
 - Elm format automatically runs every time I save a file, but there are some files I don't want it to run on
     1. If there are certain Elm source files you don't want to automatically run `elm-format` on, for example elm-css based files, you can set a regex filter which will search the full filename (including the path to the file). If the regex matches, then it will not automatically run `elm-format` on the file when you save. For example, the following filter would prevent automatic `elm-format` on a file named `elm-css/src/Css/TopBar.elm`:
         `"elm_format_filename_filter": "elm-css/src/Css/.*\\.elm$"`
+- The _Tools_ menu item is blank or the _Elm_ menu item is greyed out and I cannot select it
+    1. Install the [SublimeREPL](https://packagecontrol.io/packages/SublimeREPL) package. The 'Elm' item will appear in the _Tools > SublimeREPL_ submenu.
 
 ## Learning
 
@@ -62,7 +64,7 @@ Don't know Elm? Great first step!
 The following features are being worked on next:
 - Built in `elm-package` support. Install packages, open docs in the browser, and pull package stats from GitHub
 - Improved snippets to help with common patterns. Create a new Elm Architecture project or submodule with a basic skeleton in just a few keystrokes. Less manual boilerplate
-    
+
 [Community Forum]: https://groups.google.com/d/forum/elm-discuss
 [Elm]: http://elm-lang.org/install
 [ElmCast]: http://elmcast.io


### PR DESCRIPTION
Without SublimeREPL installed, Menus/Main.sublime-menu causes a blank Tools menu
item to appear with an unselectable 'Elm' submenu item.

Add a tip in the troubleshooting section of the README to help resolve confusion.

Signed-off-by: Yong Bakos <ybakos@humanoriented.com>