### PR TITLE
Add: a handful of useful snippets

### DIFF
--- a/Snippets/case_of.sublime-snippet
+++ b/Snippets/case_of.sublime-snippet
@@ -1,0 +1,17 @@
+<snippet>
+  <content><![CDATA[
+case $1 of
+  $2 ->
+    $3
+  ${4:_} ->
+    $5
+
+]]>
+  </content>
+  <description>ELM - case &lt;something&gt; of &lt;Condition&gt; -&gt; &lt;action&gt;</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>cof</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/case_of.sublime-snippet
+++ b/Snippets/case_of.sublime-snippet
@@ -1,17 +1,13 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 case $1 of
-  $2 ->
-    $3
-  ${4:_} ->
-    $5
-
+	$2 ->
+		$3
+	${4:_} ->
+		$5
 ]]>
-  </content>
-  <description>ELM - case &lt;something&gt; of &lt;Condition&gt; -&gt; &lt;action&gt;</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>cof</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>case … of</description>
+	<tabTrigger>cof</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/case_of_maybe.sublime-snippet
+++ b/Snippets/case_of_maybe.sublime-snippet
@@ -1,16 +1,13 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 case $1 of
-  Just $2 ->
-    $3
-  Nothing ->
-    $4
+	Just $2 ->
+		$3
+	Nothing ->
+		$4
 ]]>
-  </content>
-  <description>ELM - case &lt;Maybe&gt; of Just &lt;x&gt; -&gt; &lt;action&gt;</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>cofm</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>case … of (Maybe)</description>
+	<tabTrigger>cofm</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/case_of_maybe.sublime-snippet
+++ b/Snippets/case_of_maybe.sublime-snippet
@@ -1,0 +1,16 @@
+<snippet>
+  <content><![CDATA[
+case $1 of
+  Just $2 ->
+    $3
+  Nothing ->
+    $4
+]]>
+  </content>
+  <description>ELM - case &lt;Maybe&gt; of Just &lt;x&gt; -&gt; &lt;action&gt;</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>cofm</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/case_of_result.sublime-snippet
+++ b/Snippets/case_of_result.sublime-snippet
@@ -1,0 +1,16 @@
+<snippet>
+  <content><![CDATA[
+case $1 of
+  Ok $2 ->
+    $3
+  Error ${4:error} ->
+    $5
+]]>
+  </content>
+  <description>ELM - case &lt;Result&gt; of Ok &lt;x&gt; -&gt; &lt;action&gt;</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>cofr</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/case_of_result.sublime-snippet
+++ b/Snippets/case_of_result.sublime-snippet
@@ -1,16 +1,13 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 case $1 of
-  Ok $2 ->
-    $3
-  Error ${4:error} ->
-    $5
+	Ok $2 ->
+		$3
+	Error ${4:error} ->
+		$5
 ]]>
-  </content>
-  <description>ELM - case &lt;Result&gt; of Ok &lt;x&gt; -&gt; &lt;action&gt;</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>cofr</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>case … of (Result)</description>
+	<tabTrigger>cofr</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/function.sublime-snippet
+++ b/Snippets/function.sublime-snippet
@@ -1,0 +1,13 @@
+<snippet>
+  <content><![CDATA[
+${1:fn}: ${3:Int} -> ${2:Int}
+${1:fn} ${4:count} =
+    ${5:-- body}
+]]></content>
+
+  <description>ELM - function with one argument</description>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>fn</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/function.sublime-snippet
+++ b/Snippets/function.sublime-snippet
@@ -1,13 +1,10 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 ${1:fn}: ${3:Int} -> ${2:Int}
 ${1:fn} ${4:count} =
-    ${5:-- body}
+	${5:-- body}
 ]]></content>
-
-  <description>ELM - function with one argument</description>
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>fn</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	<description>Function (a -> b)</description>
+	<tabTrigger>fn</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/function_2_aguments.sublime-snippet
+++ b/Snippets/function_2_aguments.sublime-snippet
@@ -1,12 +1,10 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 ${1:fn}: ${3:Int} -> ${4:Int} -> ${2:Int}
 ${1:fn} ${5:a} ${6:a} =
-    ${7:-- body}
+	${7:-- body}
 ]]></content>
-  <description>ELM - function with two argument</description>
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>fn2</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	<description>Function (a -> b -> c)</description>
+	<tabTrigger>fn2</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/function_2_aguments.sublime-snippet
+++ b/Snippets/function_2_aguments.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+  <content><![CDATA[
+${1:fn}: ${3:Int} -> ${4:Int} -> ${2:Int}
+${1:fn} ${5:a} ${6:a} =
+    ${7:-- body}
+]]></content>
+  <description>ELM - function with two argument</description>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>fn2</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/function_3_aguments.sublime-snippet
+++ b/Snippets/function_3_aguments.sublime-snippet
@@ -1,12 +1,10 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 ${1:fn}: ${3:Int} -> ${4:Int} -> ${5:Int} -> ${2:Int}
 ${1:fn} ${6:a} ${7:b} ${8:c} =
-    ${9:-- body}
+	${9:-- body}
 ]]></content>
-  <description>ELM - function with tree argument</description>
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>fn3</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	<description>Function (a -> b -> c -> d)</description>
+	<tabTrigger>fn3</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/function_3_aguments.sublime-snippet
+++ b/Snippets/function_3_aguments.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+  <content><![CDATA[
+${1:fn}: ${3:Int} -> ${4:Int} -> ${5:Int} -> ${2:Int}
+${1:fn} ${6:a} ${7:b} ${8:c} =
+    ${9:-- body}
+]]></content>
+  <description>ELM - function with tree argument</description>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>fn3</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/function_4_aguments.sublime-snippet
+++ b/Snippets/function_4_aguments.sublime-snippet
@@ -1,12 +1,10 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 ${1:fn}: ${3:Int} -> ${4:Int} -> ${5:Int} -> ${6:Int} -> ${2:Int}
 ${1:fn} ${7:a} ${8:b} ${9:c} ${10:d}=
-    ${11:-- body}
+	${11:-- body}
 ]]></content>
-  <description>ELM - function with four argument</description>
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>fn4</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	<description>Function (a -> b -> c -> d -> e)</description>
+	<tabTrigger>fn4</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/function_4_aguments.sublime-snippet
+++ b/Snippets/function_4_aguments.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+  <content><![CDATA[
+${1:fn}: ${3:Int} -> ${4:Int} -> ${5:Int} -> ${6:Int} -> ${2:Int}
+${1:fn} ${7:a} ${8:b} ${9:c} ${10:d}=
+    ${11:-- body}
+]]></content>
+  <description>ELM - function with four argument</description>
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>fn4</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/import.sublime-snippet
+++ b/Snippets/import.sublime-snippet
@@ -1,12 +1,9 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 import $1${2: exposing (${3:..})}
 ]]>
-  </content>
-  <description>ELM - import &lt;name&gt;</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>imp</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>import</description>
+	<tabTrigger>imp</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/import.sublime-snippet
+++ b/Snippets/import.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+  <content><![CDATA[
+import $1${2: exposing (${3:..})}
+]]>
+  </content>
+  <description>ELM - import &lt;name&gt;</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>imp</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/import_as.sublime-snippet
+++ b/Snippets/import_as.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+  <content><![CDATA[
+import $1${2: as $3}${4: exposing (${5:..})}
+]]>
+  </content>
+  <description>ELM - import &lt;name&gt; as &lt;alias&gt;</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>impas</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/import_as.sublime-snippet
+++ b/Snippets/import_as.sublime-snippet
@@ -1,12 +1,9 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 import $1${2: as $3}${4: exposing (${5:..})}
 ]]>
-  </content>
-  <description>ELM - import &lt;name&gt; as &lt;alias&gt;</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>impas</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>import … as</description>
+	<tabTrigger>impas</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/let.sublime-snippet
+++ b/Snippets/let.sublime-snippet
@@ -1,0 +1,16 @@
+<snippet>
+  <content><![CDATA[
+let
+    $1 =
+        $2
+in
+    $3
+]]>
+  </content>
+  <description>ELM - let &lt;variable&gt; = &lt;value&gt; in &lt;action&gt;</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>let</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/let.sublime-snippet
+++ b/Snippets/let.sublime-snippet
@@ -1,16 +1,13 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 let
-    $1 =
-        $2
+	$1 =
+		$2
 in
-    $3
+		$3
 ]]>
-  </content>
-  <description>ELM - let &lt;variable&gt; = &lt;value&gt; in &lt;action&gt;</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>let</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>let … in …</description>
+	<tabTrigger>let</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/module.sublime-snippet
+++ b/Snippets/module.sublime-snippet
@@ -1,12 +1,9 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 module $1 exposing (${2:..})
 ]]>
-  </content>
-  <description>ELM - module &lt;name&gt; = exposing (&lt;..&gt;)</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>mod</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>module</description>
+	<tabTrigger>mod</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/module.sublime-snippet
+++ b/Snippets/module.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+  <content><![CDATA[
+module $1 exposing (${2:..})
+]]>
+  </content>
+  <description>ELM - module &lt;name&gt; = exposing (&lt;..&gt;)</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>mod</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/type.sublime-snippet
+++ b/Snippets/type.sublime-snippet
@@ -1,14 +1,11 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 type $1
-  = $2
-  | $3
+	= $2
+${3:	| $4}
 ]]>
-  </content>
-  <description>ELM - type &lt;name&gt; = &lt;type&gt; | &lt;type&gt;</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>type</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>type</description>
+	<tabTrigger>type</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>

--- a/Snippets/type.sublime-snippet
+++ b/Snippets/type.sublime-snippet
@@ -1,0 +1,14 @@
+<snippet>
+  <content><![CDATA[
+type $1
+  = $2
+  | $3
+]]>
+  </content>
+  <description>ELM - type &lt;name&gt; = &lt;type&gt; | &lt;type&gt;</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>type</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/type_alias.sublime-snippet
+++ b/Snippets/type_alias.sublime-snippet
@@ -1,0 +1,15 @@
+<snippet>
+  <content><![CDATA[
+type alias $1 =
+    { $2 : $3
+    , $4 : $5
+    }
+]]>
+  </content>
+  <description>ELM - type alias &lt;name&gt; = { &lt;key&gt; = &lt;type&gt;</description>
+
+  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+  <tabTrigger>typea</tabTrigger>
+  <!-- Optional: Set a scope to limit where the snippet will trigger -->
+  <scope>source.elm</scope>
+</snippet>

--- a/Snippets/type_alias.sublime-snippet
+++ b/Snippets/type_alias.sublime-snippet
@@ -1,15 +1,12 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 type alias $1 =
-    { $2 : $3
-    , $4 : $5
-    }
+	{ $2 : $3
+${4:	, $5 : $6}
+	}
 ]]>
-  </content>
-  <description>ELM - type alias &lt;name&gt; = { &lt;key&gt; = &lt;type&gt;</description>
-
-  <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-  <tabTrigger>typea</tabTrigger>
-  <!-- Optional: Set a scope to limit where the snippet will trigger -->
-  <scope>source.elm</scope>
+	</content>
+	<description>type alias (Record)</description>
+	<tabTrigger>typea</tabTrigger>
+	<scope>source.elm</scope>
 </snippet>


### PR DESCRIPTION
I used this package for a while and wanted to improve by adding some smart snippets.

Notes: 
It would be nice to have one good package for elm in sublime. I saw that there is an other package called [Elm Snippets](https://packagecontrol.io/packages/Elm%20Snippets), but I find it better to have one package together. An option is to depend on [Elm Snippets](https://packagecontrol.io/packages/Elm%20Snippets).

Also I saw this commit https://github.com/elm-community/Elm.tmLanguage/commit/3cd653dc27b3a845c8dc301550b19e3203c6c48b where we remove a folder called Snippets. I went through the commit, it look like all of those snippets just existed to have the type signature while typing. Since you added `Open Type Panel` those snippets were useless. 


The brance `snippets` was these cahnges, https://github.com/elm-community/Elm.tmLanguage/compare/master...elm-community:snippets