### PR TITLE
Allow module names with digits

### DIFF
--- a/Syntaxes/Elm.sublime-syntax
+++ b/Syntaxes/Elm.sublime-syntax
@@ -182,7 +182,7 @@ contexts:
           comment: So named because I don't know what to call this.
           scope: meta.other.unknown.elm
   module_name:
-    - match: "[A-Z][A-Za-z._']*"
+    - match: "[A-Z][A-Za-z._'0-9]*"
       scope: support.other.module.elm
   type_signature:
     - match: '\(\s*([A-Z][A-Za-z]*)\s+([a-z][A-Za-z_'']*)\)\s*(=>)'


### PR DESCRIPTION
I have module names like `Point3d` which currently cause a bit of angry red highlighting with the current syntax highlighting. I don't see any other obvious places where this should be changed - most things like variable names already allow digits. The only possible case I can see is line 188 under `type_signature` - I don't fully understand what that line does.