### PR TITLE
Elm module names can include numbers

### DIFF
--- a/Syntaxes/Elm.tmLanguage
+++ b/Syntaxes/Elm.tmLanguage
@@ -525,7 +525,7 @@
 		<key>module_name</key>
 		<dict>
 			<key>match</key>
-			<string>[A-Z][A-Za-z._']*</string>
+			<string>[A-Z][A-Za-z0-9._']*</string>
 			<key>name</key>
 			<string>support.other.module.elm</string>
 		</dict>


### PR DESCRIPTION
Here's the [before](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Felm-community%2FElm.tmLanguage%2Fblob%2Fmaster%2FSyntaxes%2FElm.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2FNoRedInk%2Fnoredink-ui%2Fmaster%2Fsrc%2FNri%2FUi%2FButton%2FV6.elm&code=):

![image](https://user-images.githubusercontent.com/2635560/71384705-b9758e80-2597-11ea-9d25-97faf9664be1.png)

...and the [after](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fmthadley%2FElm.tmLanguage%2Fec1729f597b2672bd92c96b29ece5df3c94012cd%2FSyntaxes%2FElm.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2FNoRedInk%2Fnoredink-ui%2Fmaster%2Fsrc%2FNri%2FUi%2FButton%2FV6.elm&code=):

![image](https://user-images.githubusercontent.com/2635560/71384795-39035d80-2598-11ea-95f9-0c9721940616.png)

This should also fix `import` statements, and anywhere else that references the `#module_name` key.